### PR TITLE
Bugfix. bufio: buffer full

### DIFF
--- a/client.go
+++ b/client.go
@@ -174,7 +174,7 @@ func (this *BeanstalkdClient) recvSlice(dataLen int) ([]byte, error) {
 	buf := make([]byte, dataLen+2) // Add 2 for \r\n
 	pos := 0
 	for {
-		n, e := this.reader.Read(buf)
+		n, e := this.reader.Read(buf[pos:])
 		if e != nil {
 			return nil, e
 		}

--- a/client.go
+++ b/client.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strings"
 	"time"
+	"bytes"
 )
 
 // beanstalkd job
@@ -262,6 +263,15 @@ may be:
    or disconnect and try again later.
 */
 func (this *BeanstalkdClient) Put(priority uint32, delay, ttr time.Duration, data []byte) (id uint64, err error) {
+	// Strip off newline chars
+	// i.e. json.Encoder always appends \n
+	if bytes.HasSuffix(data, []byte("\r")) {
+		data = data[ :len(data)-1]
+	}
+	if bytes.HasSuffix(data, []byte("\n")) {
+		data = data[ :len(data)-1]
+	}
+
 	cmd := fmt.Sprintf("put %d %d %d %d\r\n", priority, uint64(delay.Seconds()), uint64(ttr.Seconds()), len(data))
 	cmd = cmd + string(data) + string(crnl)
 

--- a/client.go
+++ b/client.go
@@ -170,7 +170,7 @@ func (this *BeanstalkdClient) recvLine() (string, error) {
 }
 
 func (this *BeanstalkdClient) recvSlice() ([]byte, error) {
-	return this.reader.ReadSlice('\n')
+	return this.reader.ReadBytes('\n');
 }
 
 func (this *BeanstalkdClient) recvData(data []byte) (int, error) {


### PR DESCRIPTION
ReadSlice causes a 'buffer full' error if the data field contains 'a lot' of data (in my case big JSON blob with email).

Probably when data is bigger than `defaultBufSize = 4096` bytes. This fix seems to solve the problem for me.
